### PR TITLE
Ssap 171/fix button configuration

### DIFF
--- a/examples/device/hid_composite_zephyr/src/main.c
+++ b/examples/device/hid_composite_zephyr/src/main.c
@@ -258,6 +258,7 @@ static void send_hid_report(uint8_t report_id, uint32_t btn)
   }
 }
 
+uint32_t btn;
 void hid_task(void *p1, void *p2, void *p3)
 {
   (void) p1;
@@ -269,20 +270,20 @@ void hid_task(void *p1, void *p2, void *p3)
     // Poll every 10ms
     k_msleep(10);
 
-    uint32_t const btn = board_button_read();
+    btn = board_button_read();
 
     // Remote wakeup
-    if ( tud_suspended() && btn )
-    {
-      // Wake up host if we are in suspend mode
-      // and REMOTE_WAKEUP feature is enabled by host
-      tud_remote_wakeup();
-    }
-    else
-    {
-      // Send the 1st of report chain, the rest will be sent by tud_hid_report_complete_cb()
-      send_hid_report(REPORT_ID_KEYBOARD, btn);
-    }
+    // if ( tud_suspended() && btn )
+    // {
+    //   // Wake up host if we are in suspend mode
+    //   // and REMOTE_WAKEUP feature is enabled by host
+    //   tud_remote_wakeup();
+    // }
+    // else
+    // {
+    //   // Send the 1st of report chain, the rest will be sent by tud_hid_report_complete_cb()
+    //   send_hid_report(REPORT_ID_KEYBOARD, btn);
+    // }
   }
 }
 
@@ -357,6 +358,6 @@ void led_blinky_cb(struct k_timer *timer)
   (void) timer;
   static bool led_state = false;
 
-  board_led_write(led_state);
+  // board_led_write(btn == 0);
   led_state = 1 - led_state; // toggle
 }

--- a/examples/device/hid_composite_zephyr/src/main.c
+++ b/examples/device/hid_composite_zephyr/src/main.c
@@ -258,7 +258,6 @@ static void send_hid_report(uint8_t report_id, uint32_t btn)
   }
 }
 
-uint32_t btn;
 void hid_task(void *p1, void *p2, void *p3)
 {
   (void) p1;
@@ -270,20 +269,20 @@ void hid_task(void *p1, void *p2, void *p3)
     // Poll every 10ms
     k_msleep(10);
 
-    btn = board_button_read();
+    uint32_t const btn = board_button_read();
 
     // Remote wakeup
-    // if ( tud_suspended() && btn )
-    // {
-    //   // Wake up host if we are in suspend mode
-    //   // and REMOTE_WAKEUP feature is enabled by host
-    //   tud_remote_wakeup();
-    // }
-    // else
-    // {
-    //   // Send the 1st of report chain, the rest will be sent by tud_hid_report_complete_cb()
-    //   send_hid_report(REPORT_ID_KEYBOARD, btn);
-    // }
+    if ( tud_suspended() && btn )
+    {
+      // Wake up host if we are in suspend mode
+      // and REMOTE_WAKEUP feature is enabled by host
+      tud_remote_wakeup();
+    }
+    else
+    {
+      // Send the 1st of report chain, the rest will be sent by tud_hid_report_complete_cb()
+      send_hid_report(REPORT_ID_KEYBOARD, btn);
+    }
   }
 }
 
@@ -358,6 +357,6 @@ void led_blinky_cb(struct k_timer *timer)
   (void) timer;
   static bool led_state = false;
 
-  // board_led_write(btn == 0);
+  board_led_write(led_state);
   led_state = 1 - led_state; // toggle
 }

--- a/hw/bsp/alif/family.c
+++ b/hw/bsp/alif/family.c
@@ -17,7 +17,11 @@
 #include <zephyr/sys/printk.h>
 
 static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(DT_ALIAS(led0), gpios);
-static const struct gpio_dt_spec button = GPIO_DT_SPEC_GET(DT_ALIAS(sw0), gpios);
+static const struct gpio_dt_spec btn0 = GPIO_DT_SPEC_GET(DT_ALIAS(sw0), gpios);
+static const struct gpio_dt_spec btn1 = GPIO_DT_SPEC_GET(DT_ALIAS(sw1), gpios);
+static const struct gpio_dt_spec btn2 = GPIO_DT_SPEC_GET(DT_ALIAS(sw2), gpios);
+static const struct gpio_dt_spec btn3 = GPIO_DT_SPEC_GET(DT_ALIAS(sw3), gpios);
+static const struct gpio_dt_spec btn4 = GPIO_DT_SPEC_GET(DT_ALIAS(sw4), gpios);
 #endif
 
 /**
@@ -38,8 +42,15 @@ void board_init(void) {
     if (device_is_ready(led.port)) {
       gpio_pin_configure_dt(&led, GPIO_OUTPUT_INACTIVE);
     }
-    if (device_is_ready(button.port)) {
-      gpio_pin_configure_dt(&button, GPIO_INPUT);
+    
+    gpio_pin_configure_dt(&btn4, GPIO_INPUT | GPIO_PULL_UP);
+
+      if (device_is_ready(btn0.port)) {
+    //   gpio_pin_configure_dt(&btn0, GPIO_INPUT);
+    //   gpio_pin_configure_dt(&btn1, GPIO_INPUT);
+    //   gpio_pin_configure_dt(&btn2, GPIO_INPUT);
+    //   gpio_pin_configure_dt(&btn3, GPIO_INPUT);
+    //   gpio_pin_configure_dt(&btn4, GPIO_OUTPUT_INACTIVE);
     }
 #endif
 }
@@ -71,12 +82,19 @@ uint32_t board_button_read(void) {
     return BOARD_BUTTON_STATE_LOW == btn_state;
 #endif
 #if CFG_TUSB_OS == OPT_OS_ZEPHYR
-    if (!device_is_ready(button.port)) {
-        return 0;
-    }
-    int val = gpio_pin_get(button.port, button.pin);
+    // if (!device_is_ready(btn0.port)) {
+    //     return 0;
+    // }
+    static uint8_t cnt = 0;
+    gpio_pin_set(led.port, led.pin, cnt & 1);
+    gpio_pin_set(btn4.port, btn4.pin, 1);
+    cnt++;
+    // int val = gpio_pin_get(btn4.port, btn4.pin);
 
-    return (button.dt_flags & GPIO_ACTIVE_LOW) ? (val == 0) : (val != 0);
+
+    // return (button.dt_flags & GPIO_ACTIVE_LOW) ? (val == 0) : (val != 0);
+    // return val == 0;
+    return 0;
 #endif  
 }
 

--- a/hw/bsp/alif/family.c
+++ b/hw/bsp/alif/family.c
@@ -13,6 +13,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/entropy.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/pinctrl.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 
@@ -40,6 +41,15 @@ void board_init(void) {
     }
     if (device_is_ready(button.port)) {
       gpio_pin_configure_dt(&button, GPIO_INPUT);
+
+      // FIXME: pull-up resistor is not configured by default for pin
+		pinctrl_soc_pin_t pin_cfg = 0;
+		pin_cfg |= PAD_CONF_REN(1);
+		pin_cfg |= PAD_CONF_DSC(1);
+		pin_cfg |= (120) << 3;		// port ID [9:3] (120 - LPGPIO)
+		pin_cfg |= (button.pin  & 0x07) << 0;		// pin number [2:0]
+
+        pinctrl_configure_pins(&pin_cfg, 1, NULL);
     }
 #endif
 }

--- a/hw/bsp/alif/family.c
+++ b/hw/bsp/alif/family.c
@@ -17,11 +17,7 @@
 #include <zephyr/sys/printk.h>
 
 static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(DT_ALIAS(led0), gpios);
-static const struct gpio_dt_spec btn0 = GPIO_DT_SPEC_GET(DT_ALIAS(sw0), gpios);
-static const struct gpio_dt_spec btn1 = GPIO_DT_SPEC_GET(DT_ALIAS(sw1), gpios);
-static const struct gpio_dt_spec btn2 = GPIO_DT_SPEC_GET(DT_ALIAS(sw2), gpios);
-static const struct gpio_dt_spec btn3 = GPIO_DT_SPEC_GET(DT_ALIAS(sw3), gpios);
-static const struct gpio_dt_spec btn4 = GPIO_DT_SPEC_GET(DT_ALIAS(sw4), gpios);
+static const struct gpio_dt_spec button = GPIO_DT_SPEC_GET(DT_ALIAS(sw0), gpios);
 #endif
 
 /**
@@ -42,15 +38,8 @@ void board_init(void) {
     if (device_is_ready(led.port)) {
       gpio_pin_configure_dt(&led, GPIO_OUTPUT_INACTIVE);
     }
-    
-    gpio_pin_configure_dt(&btn4, GPIO_INPUT | GPIO_PULL_UP);
-
-      if (device_is_ready(btn0.port)) {
-    //   gpio_pin_configure_dt(&btn0, GPIO_INPUT);
-    //   gpio_pin_configure_dt(&btn1, GPIO_INPUT);
-    //   gpio_pin_configure_dt(&btn2, GPIO_INPUT);
-    //   gpio_pin_configure_dt(&btn3, GPIO_INPUT);
-    //   gpio_pin_configure_dt(&btn4, GPIO_OUTPUT_INACTIVE);
+    if (device_is_ready(button.port)) {
+      gpio_pin_configure_dt(&button, GPIO_INPUT);
     }
 #endif
 }
@@ -82,19 +71,12 @@ uint32_t board_button_read(void) {
     return BOARD_BUTTON_STATE_LOW == btn_state;
 #endif
 #if CFG_TUSB_OS == OPT_OS_ZEPHYR
-    // if (!device_is_ready(btn0.port)) {
-    //     return 0;
-    // }
-    static uint8_t cnt = 0;
-    gpio_pin_set(led.port, led.pin, cnt & 1);
-    gpio_pin_set(btn4.port, btn4.pin, 1);
-    cnt++;
-    // int val = gpio_pin_get(btn4.port, btn4.pin);
+    if (!device_is_ready(button.port)) {
+        return 0;
+    }
+    int val = gpio_pin_get(button.port, button.pin);
 
-
-    // return (button.dt_flags & GPIO_ACTIVE_LOW) ? (val == 0) : (val != 0);
-    // return val == 0;
-    return 0;
+    return val == 0;
 #endif  
 }
 

--- a/src/portable/alif/alif_e7_dk/dcd_ensemble.c
+++ b/src/portable/alif/alif_e7_dk/dcd_ensemble.c
@@ -118,7 +118,7 @@ static uint32_t _sts_stage = 0;
 /// Private Functions ----------------------------------------------------------
 
 static uint8_t _dcd_start_xfer(uint8_t ep, void *buf, uint32_t size, uint8_t type);
-static void _dcd_handle_depevt(uint8_t rhport, uint8_t ep_index, uint8_t evt, uint8_t sts);
+static void _dcd_handle_depevt(uint8_t rhport, uint8_t ep, uint8_t evt, uint8_t sts);
 static void _dcd_handle_devt(uint8_t rhport, uint8_t evt, uint16_t info);
 
 void dcd_uninit(void);
@@ -459,7 +459,7 @@ void dcd_int_handler(uint8_t rhport)
 
       // dispatch the right handler for the event type
       if (0 == e.depevt.sig) { // DEPEVT
-          _dcd_handle_depevt(rhport, e.depevt.ep, e.depevt.evt, e.depevt.sts, e.depevt.par);
+          _dcd_handle_depevt(rhport, e.depevt.ep, e.depevt.evt, e.depevt.sts);
       } else if (1 == e.devt.sig) { // DEVT
           _dcd_handle_devt(rhport, e.devt.evt, e.devt.info);
       } else {
@@ -957,7 +957,7 @@ static uint8_t _dcd_cmd_wait(uint8_t ep, uint8_t typ, uint16_t param)
  * \param sts       DEPEVT status field (used for “Not Ready” codes or other flags)
  * \param par       DEPEVT parameter field (typically unused for IN/OUT transfers)
  */
-static void _dcd_handle_depevt(uint8_t rhport, uint8_t ep, uint8_t evt, uint8_t sts, uint16_t par)
+static void _dcd_handle_depevt(uint8_t rhport, uint8_t ep, uint8_t evt, uint8_t sts)
 {
 #if CFG_TUSB_OS == OPT_OS_ZEPHYR 
   if (!(ep < TUP_DCD_ENDPOINT_MAX)) {


### PR DESCRIPTION
By default the Synopsys DesignWare GPIO driver (gpio_dw.c) on Alif does not configure the pin-mux pad registers, so our push-button line never had its internal pull-up enabled. As a result, reads of the button state floated and produced incorrect values.

Solution
Add a board-level initialization call to pinctrl_configure_pin() for the button’s pin descriptor.